### PR TITLE
Update info about restricted #general posting

### DIFF
--- a/TipsForSlack.md
+++ b/TipsForSlack.md
@@ -10,13 +10,13 @@
 The #general channel is a group-wide channel to which you will automatically be added upon joining slack. This channel is restricted: since everyone is in this channel and you can't leave the channel, posting is limited to members of the Community Team for the purpose of making announcements and letting members know about community updates. Miscellaneous chit chat should take place in the #random channel.
 
 ## The #jobs channel
-The #jobs channel is a great place to find a new job, post an job listing, or just keep an eye on who is hiring. We encourage you to post jobs that you find that might be relevant to all levels of Adie experience.
+The #jobs channel is a great place to find a new job, post a job listing, or just keep an eye on who is hiring. We encourage you to post jobs that you find that might be relevant to all levels of Adie experience.
 
 To make the #jobs channel as helpful as possible, be sure to include a sentence or two about the job you are posting. If you heard about the job through a friend that you trust, mention that! If someone reached out to you on linkedin but you have no connections to the person or company, post a notice that folks might want to research for themselves. Try to avoid spamming the channel with random job posts that you find online--a good rule of thumb is to ask yourself if the post you are making has more value than a post on a job board. Sometimes it's easy to accidentally send too many posts to the #jobs channel because we all want to be helpful, but as long as you take the time to explain why you are posting this particular job then the benefit to other Adies will be evident!
 
 If you are looking for a job, please post in the #jobs channel! Post a blurb about what you've been up to recently, what kind of job or tech stack you are looking for, as well as any additional information that will help others when keeping an eye out (e.g. "I prefer mid-size startups" or "Looking for remote work" are helpful to include). Be sure to follow up with any leads shared with you and say thanks when appropriate!
 
-Remember that some Adies who are looking for jobs may not feel comfortable with their job hunt being public knowledge or may be worried that their current employer may find out. Please treat any posts in the #jobs channel confidentially unless you are given explicit permission to share that someone is looking for a job. 
+Remember that some Adies who are looking for jobs may not feel comfortable with their job hunt being public knowledge or may be worried that their current employer may find out. Please treat any posts in the #jobs or #freelancing channels confidentially unless you are given explicit permission to share that someone is looking for a job. 
 
 ## Using @here vs @channel & Do Not Disturb
 Here’s an overview of the differences:

--- a/TipsForSlack.md
+++ b/TipsForSlack.md
@@ -9,6 +9,8 @@
 ## The #general channel
 The #general channel is a group-wide channel to which you will automatically be added upon joining slack. This channel is restricted: since everyone is in this channel and you can't leave the channel, posting is limited to members of the Community Team for the purpose of making announcements and letting members know about community updates. Miscellaneous chit chat should take place in the #random channel.
 
+Anouncements for the #general channel may include updates such as changes to the Code of Conduct, this Tips document, or to welcome new Adies that are joining the channel. If you have something you'd like to share with everyone announcement style, please message the community team and we'll help you get the information out in an announcement or guide you to the right channel for posting.
+
 ## The #jobs channel
 The #jobs channel is a great place to find a new job, post a job listing, or just keep an eye on who is hiring. We encourage you to post jobs that you find that might be relevant to all levels of Adie experience.
 

--- a/TipsForSlack.md
+++ b/TipsForSlack.md
@@ -2,7 +2,7 @@
 ## Tips to make your Slack experience fun & fruitful
 * Join & participate in public channels! There is everything from #interview-questions to #personal-finance to #feelings to #python and many more.
 * Job opportunities can be posted in [#jobs](https://theadanetwork.slack.com/messages/jobs/).
-* Use the channel that is most appropriate & only cross-post when relevant. An example of when you shouldn't cross post is posting a message of "I'm selling my bike" to both #free-or-selling and #general (it should only be posted in #free-or-selling). An example of when you could cross post might be posting in both #freelancing & #jobs. 
+* Use the channel that is most appropriate & only cross-post when relevant. An example of when you shouldn't cross post is posting a message of "I'm selling my bike" to both #free-or-selling and #random (it should only be posted in #free-or-selling). An example of when you could cross post might be posting in both #freelancing & #jobs. 
 * Don't spam channels with links. Share what you found interesting or what your opinion is when you post. Check to see if someone has already posted the article, video, tweet, etc before you. If someone already has shared the thing you wanted to share, start a conversation!
 * Don't be afraid to DM! Slack is an excellent way to connect with other Ada alums who you might not already know. 
 
@@ -12,6 +12,8 @@ The #jobs channel is a great place to find a new job, post an job listing, or ju
 To make the #jobs channel as helpful as possible, be sure to include a sentence or two about the job you are posting. If you heard about the job through a friend that you trust, mention that! If someone reached out to you on linkedin but you have no connections to the person or company, post a notice that folks might want to research for themselves. Try to avoid spamming the channel with random job posts that you find online--a good rule of thumb is to ask yourself if the post you are making has more value than a post on a job board. Sometimes it's easy to accidentally send too many posts to the #jobs channel because we all want to be helpful, but as long as you take the time to explain why you are posting this particular job then the benefit to other Adies will be evident!
 
 If you are looking for a job, please post in the #jobs channel! Post a blurb about what you've been up to recently, what kind of job or tech stack you are looking for, as well as any additional information that will help others when keeping an eye out (e.g. "I prefer mid-size startups" or "Looking for remote work" are helpful to include). Be sure to follow up with any leads shared with you and say thanks when appropriate!
+
+Remember that some Adies who are looking for jobs may not feel comfortable with their job hunt being public knowledge or may be worried that their current employer may find out. Please treat any posts in the #jobs channel confidentially unless you are given explicit permission to share that someone is looking for a job. 
 
 ## Using @here vs @channel & Do Not Disturb
 Here’s an overview of the differences:
@@ -24,7 +26,7 @@ For non-urgent announcements that you want to bring to the attention of everyone
 
 We also have default Do Not Disturb setting on this slack. Notifications are automatically disabled from 22:00 to 8:00 (Get a good night’s sleep! 👵). This setting is applied to everyone as they join the slack, but you can change your own Do Not Disturb settings in your profile's settings if you’d like to change the applicable hours or turn it off completely.
 
-Please use your best judgement regarding @here and @channel. We don’t want to interfere with everyone’s ability to do their jobs, live their lives, relax, etc because their Ada slack is blowing up. If you have questions or if you have an announcement that you are unsure of how to handle, feel free to message me and we can come up with a strategy for disseminating the information.
+Please use your best judgement regarding @here and @channel. We don’t want to interfere with everyone’s ability to do their jobs, live their lives, relax, etc because their Ada slack is blowing up. If you have questions or if you have an announcement that you are unsure of how to handle, feel free to message any member of the Community Team and we can come up with a strategy for disseminating the information.
 
 ## Star vs Pin
 
@@ -34,4 +36,4 @@ Pin an item to make a message 'stick' to a channel. Everyone can see the pinned 
 
 ## Archiving & Paid Slack Plans
 
-At this point in time, we do not have the funds to pay for access to the archive of our Slack team. It costs $7/month per user. In order to ensure everyone has equal access, we will remain on the free plan.
+At this point in time, we do not have the funds to pay for access to the archive of our Slack team. It costs $7/month per user. We don't now qualify for the non-profit status. Any questions related to paying for a Slack plan may be directed back to this document. In order to ensure everyone has equal access, we will remain on the free plan.

--- a/TipsForSlack.md
+++ b/TipsForSlack.md
@@ -6,6 +6,9 @@
 * Don't spam channels with links. Share what you found interesting or what your opinion is when you post. Check to see if someone has already posted the article, video, tweet, etc before you. If someone already has shared the thing you wanted to share, start a conversation!
 * Don't be afraid to DM! Slack is an excellent way to connect with other Ada alums who you might not already know. 
 
+## The #general channel
+The #general channel is a group-wide channel to which you will automatically be added upon joining slack. This channel is restricted: since everyone is in this channel and you can't leave the channel, posting is limited to members of the Community Team for the purpose of making announcements and letting members know about community updates. Miscellaneous chit chat should take place in the #random channel.
+
 ## The #jobs channel
 The #jobs channel is a great place to find a new job, post an job listing, or just keep an eye on who is hiring. We encourage you to post jobs that you find that might be relevant to all levels of Adie experience.
 
@@ -36,4 +39,4 @@ Pin an item to make a message 'stick' to a channel. Everyone can see the pinned 
 
 ## Archiving & Paid Slack Plans
 
-At this point in time, we do not have the funds to pay for access to the archive of our Slack team. It costs $7/month per user. We don't now qualify for the non-profit status. Any questions related to paying for a Slack plan may be directed back to this document. In order to ensure everyone has equal access, we will remain on the free plan.
+At this point in time, we do not have the funds to pay for access to the archive of our Slack team. It costs $7/month per user. We don't qualify for the non-profit status. Any questions related to paying for a Slack plan may be directed back to this document. In order to ensure everyone has equal access, we will remain on the free plan.


### PR DESCRIPTION
Includes a section outlining how #general is now a restricted channel to which all members are automatically added. Explains that only Community Team members can post announcements in general.

Also adds a few misc updates & tweaks to other sections for clarity.